### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/lib/api/index.js
+++ b/lib/api/index.js
@@ -2,7 +2,7 @@
 const BodyParser = require('body-parser');
 const Cors = require('cors');
 const Express = require('express');
-const Uuid = require('node-uuid');
+const Uuid = require('uuid');
 
 const CreateLogger = require('../create-logger');
 const Db = require('../db');

--- a/lib/api/recover.js
+++ b/lib/api/recover.js
@@ -2,7 +2,7 @@
 const Async = require('async');
 const Bcrypt = require('bcrypt');
 const ValidEmail = require('email-validator').validate;
-const Uuid = require('node-uuid');
+const Uuid = require('uuid');
 
 module.exports = function Recover (req, res) {
   let reply = {

--- a/lib/api/reset.js
+++ b/lib/api/reset.js
@@ -2,7 +2,7 @@
 const Async = require('async');
 const Bcrypt = require('bcrypt');
 const ValidEmail = require('email-validator').validate;
-const Uuid = require('node-uuid');
+const Uuid = require('uuid');
 
 module.exports = function Reset (req, res) {
   let reply = {

--- a/lib/api/signup.js
+++ b/lib/api/signup.js
@@ -2,7 +2,7 @@
 const Async = require('async');
 const Bcrypt = require('bcrypt');
 const ValidEmail = require('email-validator').validate;
-const Uuid = require('node-uuid');
+const Uuid = require('uuid');
 
 module.exports = function SignUp (req, res) {
   let reply = {

--- a/lib/web-socket-relay.js
+++ b/lib/web-socket-relay.js
@@ -1,6 +1,6 @@
 'use strict';
 const EventEmitter = require('events');
-const Uuid = require('node-uuid');
+const Uuid = require('uuid');
 const WebSocket = require('ws');
 
 /**

--- a/lib/www/index.js
+++ b/lib/www/index.js
@@ -2,7 +2,7 @@
 const Express = require('express');
 const Path = require('path');
 const ServeStatic = require('serve-static');
-const Uuid = require('node-uuid');
+const Uuid = require('uuid');
 
 const CreateLogger = require('../create-logger');
 

--- a/package.json
+++ b/package.json
@@ -32,13 +32,13 @@
     "express": "4.x.x",
     "handlebars": "4.x.x",
     "letsencrypt": "1.x.x",
-    "node-uuid": "1.x.x",
     "nodemailer": "2.x.x",
     "nodemailer-markdown": "1.x.x",
     "pem": "1.x.x",
     "pg": "4.x.x",
     "pg-native": "1.x.x",
     "serve-static": "1.x.x",
+    "uuid": "^3.0.0",
     "ws": "1.x.x"
   },
   "devDependencies": {


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.